### PR TITLE
Add legal pages and update footer links

### DIFF
--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,0 +1,10 @@
+import PageLayout from "@/components/Layouts/PageLayout";
+import PrivacyPolicyContent from "@/components/Legal/PrivacyPolicyContent";
+
+export default function PrivacyPolicy() {
+  return (
+    <PageLayout title="Privacy Policy">
+      <PrivacyPolicyContent />
+    </PageLayout>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,24 @@
+import PageLayout from "@/components/Layouts/PageLayout";
+
+export default function Terms() {
+  return (
+    <PageLayout title="Terms & Conditions">
+      <section>
+        <h3 className="text-lg font-semibold mb-2">1. Use of this Website</h3>
+        <p>All content is provided for general information about OCC Events &amp; Catering. We may update it without notice.</p>
+      </section>
+      <section>
+        <h3 className="text-lg font-semibold mb-2">2. Bookings</h3>
+        <p>Any catering booking is subject to written confirmation and our separate event agreements.</p>
+      </section>
+      <section>
+        <h3 className="text-lg font-semibold mb-2">3. Liability</h3>
+        <p>We aim for accuracy but do not accept liability for loss arising from reliance on this site.</p>
+      </section>
+      <section>
+        <h3 className="text-lg font-semibold mb-2">4. Governing Law</h3>
+        <p>These terms are governed by the laws of England and Wales.</p>
+      </section>
+    </PageLayout>
+  );
+}

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -5,12 +5,12 @@ import IconWrapper from "@/components/IconWrapper/IconWrapper";
 
 const navigation = {
   main: [
-    { name: "About", href: "#" },
-    { name: "Services", href: "#" },
-    { name: "Portfolio", href: "#" },
-    { name: "Contact", href: "#" },
-    { name: "Privacy", href: "#" },
-    { name: "Terms", href: "#" },
+    { name: "About", href: "/about" },
+    { name: "Services", href: "/services" },
+    { name: "Gallery", href: "/gallery" },
+    { name: "Contact", href: "/contact" },
+    { name: "Privacy", href: "/privacy-policy" },
+    { name: "Terms", href: "/terms" },
   ],
   social: [
     {

--- a/src/components/Legal/PrivacyPolicyContent.tsx
+++ b/src/components/Legal/PrivacyPolicyContent.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+const PrivacyPolicyContent: React.FC = () => (
+  <>
+    <section>
+      <h3 className="text-lg font-semibold mb-2">1. Information We Collect</h3>
+      <p>We may collect personal details you provide including your name, contact information and any event requirements.</p>
+    </section>
+    <section>
+      <h3 className="text-lg font-semibold mb-2">2. How We Use Information</h3>
+      <p>Details you submit help us respond to enquiries, manage bookings and improve our services. We may also send occasional updates about OCC Events &amp; Catering.</p>
+    </section>
+    <section>
+      <h3 className="text-lg font-semibold mb-2">3. Sharing Your Data</h3>
+      <p>Your information is never sold. It may be shared with trusted providers solely to deliver our catering services.</p>
+    </section>
+    <section>
+      <h3 className="text-lg font-semibold mb-2">4. Data Security</h3>
+      <p>We implement industry standard measures to safeguard your data.</p>
+    </section>
+    <section>
+      <h3 className="text-lg font-semibold mb-2">5. Your Rights</h3>
+      <p>You can request access or deletion of your personal data at any time.</p>
+    </section>
+    <section>
+      <h3 className="text-lg font-semibold mb-2">6. Contact Us</h3>
+      <p>For privacy queries please email <a href="mailto:info@occevents.co.uk" className="underline">info@occevents.co.uk</a>.</p>
+    </section>
+  </>
+);
+
+export default PrivacyPolicyContent;

--- a/src/components/Modal/PrivacyPolicyModal.tsx
+++ b/src/components/Modal/PrivacyPolicyModal.tsx
@@ -1,66 +1,6 @@
 import React from "react";
 import Modal from "@/components/Modal/Modal";
-
-const PrivacyPolicyContent = () => (
-  <>
-    <section>
-      <h3 className="text-lg font-semibold mb-2">1. Information We Collect</h3>
-      <p>We collect information you provide directly to us, including:</p>
-      <ul className="list-disc list-inside ml-2">
-        <li>Name and contact information</li>
-        <li>Company details</li>
-        <li>Email address</li>
-        <li>Phone number</li>
-        <li>Message content</li>
-      </ul>
-    </section>
-
-    <section>
-      <h3 className="text-lg font-semibold mb-2">
-        2. How We Use Your Information
-      </h3>
-      <p>We use the information we collect to:</p>
-      <ul className="list-disc list-inside ml-2">
-        <li>Respond to your inquiries</li>
-        <li>Provide support</li>
-        <li>Communicate about our products and services</li>
-        <li>Improve our customer experience</li>
-      </ul>
-    </section>
-
-    <section>
-      <h3 className="text-lg font-semibold mb-2">3. Data Protection</h3>
-      <p>
-        We implement appropriate technical and organizational measures to
-        protect your personal data, including:
-      </p>
-      <ul className="list-disc list-inside ml-2">
-        <li>Encryption of data transmission</li>
-        <li>Restricted access to personal information</li>
-        <li>Regular security assessments</li>
-      </ul>
-    </section>
-
-    <section>
-      <h3 className="text-lg font-semibold mb-2">4. Your Rights</h3>
-      <p>You have the right to:</p>
-      <ul className="list-disc list-inside ml-2">
-        <li>Access your personal data</li>
-        <li>Request correction of your information</li>
-        <li>Request deletion of your data</li>
-        <li>Opt-out of marketing communications</li>
-      </ul>
-    </section>
-
-    <section>
-      <h3 className="text-lg font-semibold mb-2">5. Contact Us</h3>
-      <p>
-        If you have any questions about this privacy policy, please contact us
-        at privacy@company.com
-      </p>
-    </section>
-  </>
-);
+import PrivacyPolicyContent from "@/components/Legal/PrivacyPolicyContent";
 
 interface PrivacyPolicyModalProps {
   isOpen: boolean;


### PR DESCRIPTION
## Summary
- add reusable privacy policy content component
- create Privacy Policy and Terms & Conditions pages
- link footer items to real routes
- update privacy policy modal to reuse content

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887583ed644832db44bdd6ebb98add7