### PR TITLE
Fix footer background asset path

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -2,6 +2,7 @@ import { FiInstagram } from "react-icons/fi";
 import { SiTiktok } from "react-icons/si";
 import { IconType } from "react-icons";
 import IconWrapper from "@/components/IconWrapper/IconWrapper";
+import patternBg from "public/images/pattern-bg.png";
 
 const navigation = {
   main: [
@@ -33,7 +34,7 @@ function AppFooter() {
       <div
         className="absolute inset-0 bg-cover bg-center opacity-20 -z-20"
         style={{
-          backgroundImage: "url('/images/pattern-bg.png')",
+          backgroundImage: `url(${patternBg.src})`,
         }}
       />
 

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -2,7 +2,7 @@ import { FiInstagram } from "react-icons/fi";
 import { SiTiktok } from "react-icons/si";
 import { IconType } from "react-icons";
 import IconWrapper from "@/components/IconWrapper/IconWrapper";
-import patternBg from "public/images/pattern-bg.png";
+import patternBg from "../../../public/images/pattern-bg.png";
 
 const navigation = {
   main: [


### PR DESCRIPTION
## Summary
- load footer background image via import so Next.js resolves the asset correctly

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688797426018832d9dc7ee32f01ccc2f