### PR TITLE
Fix color opacity on About page

### DIFF
--- a/src/components/GalleryPreview/GalleryPreview.tsx
+++ b/src/components/GalleryPreview/GalleryPreview.tsx
@@ -44,7 +44,7 @@ const GalleryPreview: React.FC = () => {
   };
 
   return (
-    <section className="relative py-24 lg:py-32 bg-gradient-to-b from-elements-secondary-dimmed/10 via-neutral/10 to-elements-secondary-dimmed/10 overflow-hidden">
+    <section className="relative py-24 lg:py-32 bg-gradient-to-b from-elements-secondary-dimmed/10 via-neutral/10 to-transparent overflow-hidden">
       {/* Subtle background texture */}
       <div className="absolute inset-0 opacity-30">
         <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-gradient-to-br from-elements-primary-main/3 to-transparent rounded-full blur-3xl" />

--- a/src/components/SectionHeader/SectionHeader.tsx
+++ b/src/components/SectionHeader/SectionHeader.tsx
@@ -94,7 +94,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
       {badge && (
         <motion.div variants={variants}>
           <span
-            className={`inline-block px-6 py-3 rounded-sm bg-elements-primary-main/8 border border-elements-primary-main/15 text-elements-primary-main text-sm font-light tracking-[0.2em] uppercase ${alignmentClasses.badge}`}
+            className={`inline-block px-6 py-3 rounded-sm bg-elements-primary-main/20 border border-elements-primary-main/25 text-elements-primary-main text-sm font-light tracking-[0.2em] uppercase ${alignmentClasses.badge}`}
           >
             {badge}
           </span>

--- a/src/components/SectionHeader/SectionHeader.tsx
+++ b/src/components/SectionHeader/SectionHeader.tsx
@@ -94,7 +94,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
       {badge && (
         <motion.div variants={variants}>
           <span
-            className={`inline-block px-6 py-3 rounded-sm bg-elements-primary-main/20 border border-elements-primary-main/25 text-elements-primary-main text-sm font-light tracking-[0.2em] uppercase ${alignmentClasses.badge}`}
+            className={`inline-block px-6 py-3 rounded-sm bg-elements-primary-main/5 border border-elements-primary-main/25 text-elements-primary-main text-sm font-light tracking-[0.2em] uppercase ${alignmentClasses.badge}`}
           >
             {badge}
           </span>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -142,10 +142,24 @@ const config: Config = {
   ],
 };
 
+function hexToRgb(hex: string) {
+  const cleaned = hex.replace("#", "");
+  const bigint = parseInt(cleaned, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `${r} ${g} ${b}`;
+}
+
 function addVariablesForColors({ addBase, theme }: any) {
-  let allColors = flattenColorPalette(theme("colors"));
-  let newVars = Object.fromEntries(
-    Object.entries(allColors).map(([key, val]) => [`--${key}`, val])
+  const allColors = flattenColorPalette(theme("colors"));
+  const newVars = Object.fromEntries(
+    Object.entries(allColors).map(([key, val]) => {
+      if (typeof val === "string" && /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(val)) {
+        return [`--${key}`, hexToRgb(val)];
+      }
+      return [`--${key}`, val];
+    })
   );
 
   addBase({


### PR DESCRIPTION
## Summary
- convert hex theme colors to RGB when generating CSS variables to support `/opacity` modifiers
- adjust SectionHeader badge color opacity so it's more visible

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_6888d724eb48832d81939379a7f6027e