### PR TITLE
Improve hero section consistency

### DIFF
--- a/src/components/AboutPreview/AboutPreview.tsx
+++ b/src/components/AboutPreview/AboutPreview.tsx
@@ -197,10 +197,10 @@ const AboutPreview: React.FC = () => {
               />
 
               {/* Gradient Overlay */}
-              <div className="absolute inset-0 bg-gradient-to-t from-black/20 via-transparent to-transparent" />
+              <div className="absolute inset-0 bg-gradient-to-t from-neutral-shadow-heavy/20 via-transparent to-transparent" />
 
               {/* Decorative Frame */}
-              <div className="absolute inset-4 border border-white/20 rounded-lg pointer-events-none" />
+              <div className="absolute inset-4 border border-border-white/20 rounded-lg pointer-events-none" />
             </div>
 
             {/* Floating Quote Card */}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -14,13 +14,12 @@ const chooseButtonClassName = (type: string) => {
       return "inline-flex justify-center rounded-md px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary items-center";
     case "icon":
       return "inline-flex justify-center items-center rounded-md p-2 text-text-secondary hover:text-text-primary hover:bg-button-hover";
-    // New hero-style buttons
     case "hero-primary":
-      return "group relative overflow-hidden inline-flex justify-center items-center px-6 py-3 sm:px-10 sm:py-4 bg-white text-neutral-900 font-medium tracking-wide rounded-sm border border-white/20 hover:bg-neutral-50 transition-all duration-500 hover:scale-105 hover:shadow-2xl hover:shadow-white/10 text-sm sm:text-base";
+      return "group relative overflow-hidden inline-flex justify-center items-center px-6 py-3 sm:px-10 sm:py-4 bg-card-background text-text-primary font-medium tracking-wide rounded-sm border border-border-white/20 hover:bg-neutral-dimmed transition-all duration-500 hover:scale-105 hover:shadow-2xl hover:shadow-border-white/10 text-sm sm:text-base";
     case "hero-secondary":
-      return "group relative overflow-hidden inline-flex justify-center items-center px-6 py-3 sm:px-10 sm:py-4 bg-transparent text-white font-medium tracking-wide rounded-sm border border-white/40 hover:border-white/60 transition-all duration-500 hover:scale-105 text-sm sm:text-base";
+      return "group relative overflow-hidden inline-flex justify-center items-center px-6 py-3 sm:px-10 sm:py-4 bg-transparent text-text-clear font-medium tracking-wide rounded-sm border border-border-white/40 hover:border-border-white/60 transition-all duration-500 hover:scale-105 text-sm sm:text-base";
     case "elegant-primary":
-      return "group relative overflow-hidden inline-flex justify-center items-center px-8 py-3 bg-elements-primary-main text-white font-medium tracking-wide rounded-sm hover:bg-elements-primary-shadow transition-all duration-500 hover:scale-105 hover:shadow-xl hover:shadow-elements-primary-main/25";
+      return "group relative overflow-hidden inline-flex justify-center items-center px-8 py-3 bg-elements-primary-main text-text-clear font-medium tracking-wide rounded-sm hover:bg-elements-primary-shadow transition-all duration-500 hover:scale-105 hover:shadow-xl hover:shadow-elements-primary-main/25";
     case "elegant-secondary":
       return "group relative overflow-hidden inline-flex justify-center items-center px-8 py-3 bg-transparent text-text-primary font-medium tracking-wide rounded-sm border border-border-dimmed hover:border-text-primary transition-all duration-500 hover:scale-105";
     default:
@@ -82,7 +81,7 @@ const Button = ({
         <div className="absolute inset-0 bg-gradient-to-r from-elements-primary-main/10 to-elements-secondary-main/10 transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 origin-left" />
       )}
       {(type === "hero-secondary" || type === "elegant-secondary") && (
-        <div className="absolute inset-0 bg-white/5 transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 origin-left" />
+        <div className="absolute inset-0 bg-border-white/5 transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 origin-left" />
       )}
     </>
   );

--- a/src/components/GalleryPreview/GalleryPreview.tsx
+++ b/src/components/GalleryPreview/GalleryPreview.tsx
@@ -96,10 +96,10 @@ const GalleryPreview: React.FC = () => {
                   {/* Caption overlay */}
                   <div className="absolute bottom-0 left-0 right-0 p-8 lg:p-10">
                     <div className="transform translate-y-2 group-hover:translate-y-0 transition-transform duration-500">
-                      <p className="text-white/80 text-sm font-light tracking-wide mb-2 uppercase">
+                      <p className="text-text-clear/80 text-sm font-light tracking-wide mb-2 uppercase">
                         {galleryImages[0].description}
                       </p>
-                      <h3 className="text-white text-2xl lg:text-3xl font-light tracking-wide">
+                      <h3 className="text-text-clear text-2xl lg:text-3xl font-light tracking-wide">
                         {galleryImages[0].caption}
                       </h3>
                     </div>
@@ -128,10 +128,10 @@ const GalleryPreview: React.FC = () => {
 
                       <div className="absolute bottom-0 left-0 right-0 p-6">
                         <div className="transform translate-y-2 group-hover:translate-y-0 transition-transform duration-500">
-                          <p className="text-white/80 text-xs font-light tracking-wide mb-1 uppercase">
+                          <p className="text-text-clear/80 text-xs font-light tracking-wide mb-1 uppercase">
                             {image.description}
                           </p>
-                          <h3 className="text-white text-lg font-light tracking-wide">
+                          <h3 className="text-text-clear text-lg font-light tracking-wide">
                             {image.caption}
                           </h3>
                         </div>
@@ -163,10 +163,10 @@ const GalleryPreview: React.FC = () => {
 
                     <div className="absolute bottom-0 left-0 right-0 p-6">
                       <div className="transform translate-y-2 group-hover:translate-y-0 transition-transform duration-500">
-                        <p className="text-white/80 text-xs font-light tracking-wide mb-1 uppercase">
+                        <p className="text-text-clear/80 text-xs font-light tracking-wide mb-1 uppercase">
                           {image.description}
                         </p>
-                        <h3 className="text-white text-lg font-light tracking-wide">
+                        <h3 className="text-text-clear text-lg font-light tracking-wide">
                           {image.caption}
                         </h3>
                       </div>

--- a/src/components/HeroSection/HeroSection.tsx
+++ b/src/components/HeroSection/HeroSection.tsx
@@ -2,12 +2,10 @@
 
 import React, { useState, useEffect } from "react";
 import { motion, AnimatePresence, Variant, Variants } from "framer-motion";
-import Link from "next/link";
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
-import Button from "@/components/Button/Button"; // Add Button import
+import Button from "@/components/Button/Button";
 import { carouselImages } from "@/data/hero";
 
-// Define proper types for the animation variants
 interface TextVariants extends Variants {
   hidden: Variant;
   visible: Variant;
@@ -100,7 +98,7 @@ const HeroCarousel: React.FC = () => {
               }}
             />
             {/* Dark overlay for better text readability */}
-            <div className="absolute inset-0 bg-black/40" />
+            <div className="absolute inset-0 bg-neutral-shadow-heavy/40" />
           </motion.div>
         </AnimatePresence>
       </div>
@@ -110,7 +108,7 @@ const HeroCarousel: React.FC = () => {
         onClick={handlePrev}
         onMouseEnter={() => setIsAutoPlaying(false)}
         onMouseLeave={() => setIsAutoPlaying(true)}
-        className="absolute left-2 sm:left-8 top-1/2 -translate-y-1/2 z-30 p-2 sm:p-4 bg-white/5 backdrop-blur-md border border-white/10 text-white hover:bg-white/10 transition-all duration-500 group"
+        className="absolute left-2 sm:left-8 top-1/2 -translate-y-1/2 z-30 p-2 sm:p-4 bg-border-white/5 backdrop-blur-md border border-border-white/10 text-text-clear hover:bg-border-white/10 transition-all duration-500 group"
         aria-label="Previous image"
       >
         <ChevronLeftIcon className="w-4 h-4 sm:w-5 sm:h-5 group-hover:scale-110 transition-transform duration-300" />
@@ -120,7 +118,7 @@ const HeroCarousel: React.FC = () => {
         onClick={handleNext}
         onMouseEnter={() => setIsAutoPlaying(false)}
         onMouseLeave={() => setIsAutoPlaying(true)}
-        className="absolute right-2 sm:right-8 top-1/2 -translate-y-1/2 z-30 p-2 sm:p-4 bg-white/5 backdrop-blur-md border border-white/10 text-white hover:bg-white/10 transition-all duration-500 group"
+        className="absolute right-2 sm:right-8 top-1/2 -translate-y-1/2 z-30 p-2 sm:p-4 bg-border-white/5 backdrop-blur-md border border-border-white/10 text-text-clear hover:bg-border-white/10 transition-all duration-500 group"
         aria-label="Next image"
       >
         <ChevronRightIcon className="w-4 h-4 sm:w-5 sm:h-5 group-hover:scale-110 transition-transform duration-300" />
@@ -136,8 +134,8 @@ const HeroCarousel: React.FC = () => {
             onMouseLeave={() => setIsAutoPlaying(true)}
             className={`w-6 sm:w-8 h-px transition-all duration-500 ${
               index === currentIndex
-                ? "bg-white"
-                : "bg-white/30 hover:bg-white/60"
+                ? "bg-border-white"
+                : "bg-border-white/30 hover:bg-border-white/60"
             }`}
             aria-label={`Go to slide ${index + 1}`}
           />
@@ -155,7 +153,7 @@ const HeroCarousel: React.FC = () => {
             transition={{ duration: 0.8, delay: 0.2 }}
             className="mb-4 sm:mb-8"
           >
-            <span className="inline-block px-3 py-1 sm:px-6 sm:py-2 rounded-sm bg-white/10 backdrop-blur-md border border-white/20 text-white text-xs sm:text-sm font-light tracking-widest uppercase">
+            <span className="inline-block px-3 py-1 sm:px-6 sm:py-2 rounded-sm bg-border-white/10 backdrop-blur-md border border-border-white/20 text-text-clear text-xs sm:text-sm font-light tracking-widest uppercase">
               {carouselImages[currentIndex].subtitle}
             </span>
           </motion.div>
@@ -169,7 +167,7 @@ const HeroCarousel: React.FC = () => {
               delay: 0.4,
               ease: [0.4, 0.0, 0.2, 1],
             }}
-            className="text-3xl sm:text-4xl md:text-6xl lg:text-7xl font-light tracking-wide text-white mb-4 sm:mb-8 leading-tight px-2"
+            className="text-3xl sm:text-4xl md:text-6xl lg:text-7xl font-extralight tracking-wide text-text-clear mb-4 sm:mb-8 leading-tight px-2"
           >
             Memorable Events
             <br />
@@ -184,7 +182,7 @@ const HeroCarousel: React.FC = () => {
             initial="hidden"
             animate="visible"
             transition={{ duration: 0.8, delay: 0.8 }}
-            className="mx-auto max-w-2xl text-sm sm:text-lg md:text-xl text-gray-200/90 leading-relaxed mb-8 sm:mb-12 font-light tracking-wide px-4"
+            className="mx-auto max-w-2xl text-sm sm:text-lg md:text-xl text-text-clear/90 leading-relaxed mb-8 sm:mb-12 font-light tracking-wide px-4"
           >
             At OCC Events & Catering, we specialise in bespoke Indian and Afghan
             menus that make every occasion unforgettable. Let's bring your
@@ -199,22 +197,13 @@ const HeroCarousel: React.FC = () => {
             transition={{ duration: 0.8, delay: 1.2 }}
             className="flex flex-col sm:flex-row gap-6 justify-center items-center"
           >
-            <Link
+            <Button
+              type="hero-primary"
               href="/contact"
-              className="group relative overflow-hidden px-10 py-4 bg-white text-neutral-900 font-medium tracking-wide rounded-sm border border-white/20 hover:bg-neutral-50 transition-all duration-500 hover:scale-105 hover:shadow-2xl hover:shadow-white/10"
-            >
-              <span className="relative z-10">Get Quote</span>
-              <div className="absolute inset-0 bg-gradient-to-r from-elements-primary-main/10 to-elements-secondary-main/10 transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 origin-left" />
-            </Link>
-
-            <Link
-              href="/gallery"
-              className="group relative overflow-hidden px-10 py-4 bg-transparent text-white font-medium tracking-wide rounded-sm border border-white/40 hover:border-white/60 transition-all duration-500 hover:scale-105"
-            >
-              <span className="relative z-10 flex items-center">
-                View Gallery
+              extraClassNames="!px-10 !py-4"
+              icon={
                 <svg
-                  className="ml-3 w-4 h-4 transition-transform duration-300 group-hover:translate-x-1"
+                  className="w-4 h-4 transition-transform duration-300 group-hover:translate-x-1"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -226,9 +215,33 @@ const HeroCarousel: React.FC = () => {
                     d="M17 8l4 4m0 0l-4 4m4-4H3"
                   />
                 </svg>
-              </span>
-              <div className="absolute inset-0 bg-white/5 transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 origin-left" />
-            </Link>
+              }
+            >
+              Get Quote
+            </Button>
+
+            <Button
+              type="hero-secondary"
+              href="/gallery"
+              extraClassNames="!px-10 !py-4"
+              icon={
+                <svg
+                  className="w-4 h-4 transition-transform duration-300 group-hover:translate-x-1"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.5}
+                    d="M17 8l4 4m0 0l-4 4m4-4H3"
+                  />
+                </svg>
+              }
+            >
+              View Gallery
+            </Button>
           </motion.div>
 
           {/* Scroll indicator */}
@@ -238,8 +251,8 @@ const HeroCarousel: React.FC = () => {
             transition={{ duration: 1, delay: 1.8 }}
             className="absolute -bottom-40 left-1/2 -translate-x-1/2"
           >
-            <div className="flex flex-col items-center space-y-4 text-white/60">
-              <span className="text-xs font-light tracking-[0.2em] uppercase">
+            <div className="flex flex-col items-center space-y-4 text-text-clear/60">
+              <span className="text-sm font-light tracking-[0.2em] uppercase">
                 Scroll to explore
               </span>
               <motion.div
@@ -249,7 +262,7 @@ const HeroCarousel: React.FC = () => {
                   repeat: Infinity,
                   ease: "easeInOut",
                 }}
-                className="w-px h-12 bg-gradient-to-b from-transparent via-white/40 to-transparent"
+                className="w-px h-12 bg-gradient-to-b from-transparent via-border-white/40 to-transparent"
               />
               <motion.div
                 animate={{ y: [0, 12, 0] }}
@@ -259,7 +272,7 @@ const HeroCarousel: React.FC = () => {
                   ease: "easeInOut",
                   delay: 0.5,
                 }}
-                className="w-1 h-1 bg-white/60 rounded-full"
+                className="w-1 h-1 bg-border-white/60 rounded-full"
               />
             </div>
           </motion.div>
@@ -267,7 +280,7 @@ const HeroCarousel: React.FC = () => {
       </div>
 
       {/* Progress bar */}
-      <div className="absolute top-0 left-0 w-full h-1 bg-white/20 z-30">
+      <div className="absolute top-0 left-0 w-full h-1 bg-border-white/20 z-30">
         <motion.div
           key={currentIndex}
           className="h-full bg-gradient-to-r from-elements-primary-main to-elements-secondary-main"

--- a/src/components/ServicesOverview/ServicesOverview.tsx
+++ b/src/components/ServicesOverview/ServicesOverview.tsx
@@ -99,10 +99,10 @@ const ServicesOverview: React.FC = () => {
             <div className="absolute inset-0 flex flex-col justify-end p-6 lg:p-8">
               {/* Default State - Just Title */}
               <div className="transform transition-all duration-500 ease-out group-hover:-translate-y-8 group-hover:opacity-0">
-                <h3 className="text-2xl lg:text-3xl font-light text-white mb-2 tracking-wide">
+                <h3 className="text-2xl lg:text-3xl font-light text-text-clear mb-2 tracking-wide">
                   {service.title}
                 </h3>
-                <div className="w-12 h-0.5 bg-white/60 rounded-full" />
+                <div className="w-12 h-0.5 bg-border-white/60 rounded-full" />
               </div>
 
               {/* Hover State - Full Content */}
@@ -110,14 +110,14 @@ const ServicesOverview: React.FC = () => {
                 <div className="space-y-6">
                   {/* Title with Icon */}
                   <div className="space-y-3">
-                    <h3 className="text-2xl lg:text-3xl font-light text-white tracking-wide">
+                    <h3 className="text-2xl lg:text-3xl font-light text-text-clear tracking-wide">
                       {service.title}
                     </h3>
                     <div className="w-16 h-0.5 bg-gradient-to-r from-elements-primary-main to-elements-secondary-main rounded-full" />
                   </div>
 
                   {/* Description */}
-                  <p className="text-white/90 leading-relaxed font-light text-sm lg:text-base">
+                  <p className="text-text-clear/90 leading-relaxed font-light text-sm lg:text-base">
                     {service.description}
                   </p>
 
@@ -127,7 +127,7 @@ const ServicesOverview: React.FC = () => {
                     href={`/services/${service.title
                       .toLowerCase()
                       .replace(/\s+/g, "-")}`}
-                    extraClassNames="!px-6 !py-2 !text-sm border-white/60 hover:border-white text-white"
+                    extraClassNames="!px-6 !py-2 !text-sm border-border-white/60 hover:border-border-white text-text-clear"
                     icon={
                       <svg
                         className="w-3 h-3 transition-transform duration-300 group-hover:translate-x-1"
@@ -151,9 +151,9 @@ const ServicesOverview: React.FC = () => {
 
               {/* Hover Indicator */}
               <div className="absolute top-6 right-6 opacity-0 group-hover:opacity-100 transition-all duration-300 delay-200">
-                <div className="w-8 h-8 border border-white/40 rounded-full flex items-center justify-center">
+                <div className="w-8 h-8 border border-border-white/40 rounded-full flex items-center justify-center">
                   <svg
-                    className="w-4 h-4 text-white"
+                    className="w-4 h-4 text-text-clear"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -170,8 +170,8 @@ const ServicesOverview: React.FC = () => {
             </div>
 
             {/* Subtle Border Between Items */}
-            <div className="absolute right-0 top-0 bottom-0 w-px bg-white/10 hidden lg:block last:hidden" />
-            <div className="absolute bottom-0 left-0 right-0 h-px bg-white/10 md:hidden" />
+            <div className="absolute right-0 top-0 bottom-0 w-px bg-border-white/10 hidden lg:block last:hidden" />
+            <div className="absolute bottom-0 left-0 right-0 h-px bg-border-white/10 md:hidden" />
           </motion.div>
         ))}
       </motion.div>


### PR DESCRIPTION
## Summary
- use shared `Button` component for hero CTAs
- tweak hero typography and colours for consistency
- replace hard-coded colours with theme variables

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a0c58edc8832da52e57cdb94fe099