### PR TITLE
Move About page content to data

### DIFF
--- a/src/components/About/AboutCTASection/AboutCTASection.tsx
+++ b/src/components/About/AboutCTASection/AboutCTASection.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { motion } from "framer-motion";
 import Button from "@/components/Button/Button";
+import { aboutCTAData } from "@/data";
 
 interface AboutCTASectionProps {
   itemVariants: any;
@@ -15,7 +16,7 @@ const AboutCTASection: React.FC<AboutCTASectionProps> = ({ itemVariants }) => {
       <div
         className="absolute inset-0 bg-cover bg-center z-0"
         style={{
-          backgroundImage: "url('/images/cta-background.jpg')", // replace with your image
+          backgroundImage: `url('${aboutCTAData.backgroundImage}')`,
         }}
       >
         {/* Primary colour overlay */}
@@ -34,13 +35,14 @@ const AboutCTASection: React.FC<AboutCTASectionProps> = ({ itemVariants }) => {
           className="text-center"
         >
           <h2 className="text-3xl lg:text-5xl font-light leading-tight mb-6">
-            Ready to Create Your{" "}
-            <span className="font-serif italic text-white">Perfect Event?</span>
+            {aboutCTAData.heading.preface}{" "}
+            <span className="font-serif italic text-white">
+              {aboutCTAData.heading.highlight}
+            </span>
           </h2>
 
           <p className="text-lg lg:text-xl font-light opacity-90 max-w-2xl mx-auto mb-10 leading-relaxed">
-            Let’s bring your vision to life with our signature blend of
-            authentic flavours and heartfelt service.
+            {aboutCTAData.description}
           </p>
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center">

--- a/src/components/About/AboutIntroSection/AboutIntroSection.tsx
+++ b/src/components/About/AboutIntroSection/AboutIntroSection.tsx
@@ -4,6 +4,7 @@ import React, { useRef } from "react";
 import { motion, useInView } from "framer-motion";
 import Image from "next/image";
 import SectionHeader from "@/components/SectionHeader/SectionHeader";
+import { aboutIntroData } from "@/data";
 
 interface AboutIntroSectionProps {
   containerVariants: any;
@@ -32,10 +33,10 @@ const AboutIntroSection: React.FC<AboutIntroSectionProps> = ({
           {/* Text Content */}
           <div>
             <SectionHeader
-              badge="About The OCC"
-              title="Crafting Moments"
-              subtitle="Creating Memories"
-              description="At The OCC Events and Catering, we believe every celebration deserves to be extraordinary. Born from a passion for authentic Indian and Afghan cuisine, we've grown into a trusted partner for life's most meaningful moments."
+              badge={aboutIntroData.header.badge}
+              title={aboutIntroData.header.title}
+              subtitle={aboutIntroData.header.subtitle}
+              description={aboutIntroData.header.description}
               alignment="left"
               maxWidth="full"
               showDecorator={true}
@@ -46,10 +47,7 @@ const AboutIntroSection: React.FC<AboutIntroSectionProps> = ({
               variants={itemVariants}
               className="text-base leading-relaxed text-text-tertiary font-light py-8"
             >
-              Our approach is simple: combine traditional flavours with modern
-              elegance, delivered with the personal touch that makes each event
-              uniquely yours. From intimate gatherings to grand celebrations, we
-              bring authenticity and artistry to every plate.
+              {aboutIntroData.paragraph}
             </motion.p>
 
             <motion.div
@@ -62,10 +60,10 @@ const AboutIntroSection: React.FC<AboutIntroSectionProps> = ({
                 transition={{ duration: 0.6 }}
                 className="text-4xl font-semibold text-elements-primary-main"
               >
-                125+
+                {aboutIntroData.stats.value}
               </motion.span>
               <p className="text-sm text-text-tertiary font-light max-w-xs">
-                Events crafted with care, flavour, and unforgettable memories.
+                {aboutIntroData.stats.description}
               </p>
             </motion.div>
           </div>
@@ -79,8 +77,8 @@ const AboutIntroSection: React.FC<AboutIntroSectionProps> = ({
             className="rounded-xl overflow-hidden shadow-xl"
           >
             <Image
-              src="/images/about/intro-main.jpg"
-              alt="Elegant dining setup showcasing OCC Events"
+              src={aboutIntroData.image.src}
+              alt={aboutIntroData.image.alt}
               width={700}
               height={500}
               className="w-full h-full object-cover"

--- a/src/components/About/AboutStorySection/AboutStorySection.tsx
+++ b/src/components/About/AboutStorySection/AboutStorySection.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import Image from "next/image";
 import SectionHeader from "@/components/SectionHeader/SectionHeader";
+import { aboutStoryData } from "@/data";
 
 interface AboutStorySectionProps {
   containerVariants: any;
@@ -51,23 +52,7 @@ const AboutStorySection: React.FC<AboutStorySectionProps> = ({
             <div className="lg:col-span-7 space-y-16">
               <div className="space-y-12">
                 {/* Timeline Item */}
-                {[
-                  {
-                    date: "2016 • The Beginning",
-                    text: "The OCC began with a simple dream: to share the rich culinary traditions of India and Afghanistan with our community. What started as intimate gatherings for friends and family has blossomed into something extraordinary.",
-                    color: "bg-elements-primary-main",
-                  },
-                  {
-                    date: "The Foundation",
-                    text: "Our founder, Amara Singh, grew up surrounded by aromatic spices and time-honored recipes passed down through generations. She recognised that food is more than sustenance — it's the heart of every celebration.",
-                    color: "bg-elements-secondary-main",
-                  },
-                  {
-                    date: "Today • Our Promise",
-                    text: "We're proud to be the trusted choice for celebrations throughout the region. While we've grown, our commitment remains unchanged: every dish is prepared with love, every event is planned with care.",
-                    color: "bg-elements-primary-main",
-                  },
-                ].map(({ date, text, color }, i) => (
+                {aboutStoryData.timeline.map(({ date, text, color }, i) => (
                   <motion.div
                     key={i}
                     variants={itemVariants}
@@ -88,11 +73,7 @@ const AboutStorySection: React.FC<AboutStorySectionProps> = ({
 
               {/* Stats */}
               <div className="grid grid-cols-3 gap-8 pt-12 border-t border-border-dimmed/20">
-                {[
-                  { label: "Events", value: "500+" },
-                  { label: "Years", value: "8+" },
-                  { label: "Satisfaction", value: "98%" },
-                ].map((stat, i) => (
+                {aboutStoryData.stats.map((stat, i) => (
                   <div key={i} className="text-center">
                     <p className="text-3xl font-light text-elements-primary-main mb-2">
                       {stat.value}
@@ -113,8 +94,8 @@ const AboutStorySection: React.FC<AboutStorySectionProps> = ({
                 className="group relative aspect-[4/3] rounded-2xl overflow-hidden shadow-2xl"
               >
                 <Image
-                  src="/images/about/story-image.jpg"
-                  alt="Traditional spices and ingredients"
+                  src={aboutStoryData.image.src}
+                  alt={aboutStoryData.image.alt}
                   fill
                   className="object-cover group-hover:scale-105 transition-transform duration-700"
                   sizes="(max-width: 768px) 100vw, 40vw"
@@ -134,18 +115,16 @@ const AboutStorySection: React.FC<AboutStorySectionProps> = ({
                 className="relative pl-8 border-l-4 border-elements-primary-main/50"
               >
                 <blockquote className="text-xl italic text-text-primary font-light leading-relaxed mb-4">
-                  "Every spice tells a story, every dish carries tradition, and
-                  every event we cater becomes a bridge between cultures and
-                  hearts."
+                  {aboutStoryData.quote}
                 </blockquote>
                 <div className="flex items-center space-x-4 mt-4">
                   <div className="w-12 h-12 bg-gradient-to-br from-elements-primary-main/20 to-elements-secondary-main/20 rounded-full" />
                   <div>
                     <p className="text-base font-medium text-text-primary">
-                      Amara Singh
+                      {aboutStoryData.author}
                     </p>
                     <p className="text-sm text-text-tertiary">
-                      Founder & Executive Chef
+                      {aboutStoryData.authorTitle}
                     </p>
                   </div>
                 </div>

--- a/src/components/About/AboutTeamSection/AboutTeamSection.tsx
+++ b/src/components/About/AboutTeamSection/AboutTeamSection.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import Image from "next/image";
 import SectionHeader from "@/components/SectionHeader/SectionHeader";
+import { aboutTeamData } from "@/data";
 
 interface TeamMember {
   name: string;
@@ -21,32 +22,7 @@ const AboutTeamSection: React.FC<AboutTeamSectionProps> = ({
   containerVariants,
   itemVariants,
 }) => {
-  const teamMembers: TeamMember[] = [
-    {
-      name: "Amara Singh",
-      role: "Founder & Executive Chef",
-      image: "/images/team/amara.jpg",
-      bio: "With over 15 years of culinary excellence, Amara brings authentic Indian and Afghan flavors to every celebration.",
-    },
-    {
-      name: "James Mitchell",
-      role: "Operations Director",
-      image: "/images/team/james.jpg",
-      bio: "James ensures every event runs seamlessly, coordinating logistics with precision and care.",
-    },
-    {
-      name: "Priya Patel",
-      role: "Creative Director",
-      image: "/images/team/priya.jpg",
-      bio: "Priya transforms visions into reality, crafting bespoke experiences that reflect each client's unique story.",
-    },
-    {
-      name: "David Chen",
-      role: "Head of Service",
-      image: "/images/team/david.jpg",
-      bio: "David leads our service team with warmth and professionalism, ensuring every guest feels valued.",
-    },
-  ];
+  const teamMembers: TeamMember[] = aboutTeamData.members;
 
   return (
     <section className="relative py-24 bg-gradient-to-b from-neutral/20 via-card-background to-neutral/20 overflow-hidden">
@@ -63,10 +39,10 @@ const AboutTeamSection: React.FC<AboutTeamSectionProps> = ({
           {/* Section Header */}
           <motion.div variants={itemVariants} className="text-center mb-20">
             <SectionHeader
-              badge="Our Team"
-              title="The Hearts Behind"
-              subtitle="Every Event"
-              description="Meet the passionate individuals who bring creativity, expertise, and genuine care to every celebration we have the honor to be part of."
+              badge={aboutTeamData.header.badge}
+              title={aboutTeamData.header.title}
+              subtitle={aboutTeamData.header.subtitle}
+              description={aboutTeamData.header.description}
               alignment="center"
               maxWidth="2xl"
               showDecorator={true}

--- a/src/components/About/AboutValuesSection/AboutValuesSection.tsx
+++ b/src/components/About/AboutValuesSection/AboutValuesSection.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { motion } from "framer-motion";
 import SectionHeader from "@/components/SectionHeader/SectionHeader";
+import { aboutValuesData } from "@/data";
 
 interface Value {
   number: string;
@@ -20,43 +21,7 @@ const AboutValuesSection: React.FC<AboutValuesSectionProps> = ({
   containerVariants,
   itemVariants,
 }) => {
-  const values: Value[] = [
-    {
-      number: "01",
-      title: "Personal Touch",
-      description:
-        "Every event is crafted with individual attention, reflecting your unique story and vision. We believe in creating intimate connections through exceptional culinary experiences.",
-      highlight: "Individual Attention",
-    },
-    {
-      number: "02",
-      title: "Authentic Excellence",
-      description:
-        "We honor traditional flavors while embracing modern presentation and dietary preferences. Our heritage recipes meet contemporary sophistication.",
-      highlight: "Traditional Heritage",
-    },
-    {
-      number: "03",
-      title: "Trust & Reliability",
-      description:
-        "Your special moments deserve unwavering commitment. We deliver on every promise, every time, ensuring peace of mind throughout your celebration.",
-      highlight: "Unwavering Commitment",
-    },
-    {
-      number: "04",
-      title: "Creative Innovation",
-      description:
-        "From intimate gatherings to grand celebrations, we bring fresh ideas and artistic flair to every plate and presentation.",
-      highlight: "Fresh Ideas",
-    },
-    {
-      number: "05",
-      title: "Lasting Memories",
-      description:
-        "We don't just cater events; we create experiences that you and your guests will treasure forever. Every detail contributes to unforgettable moments.",
-      highlight: "Unforgettable Moments",
-    },
-  ];
+  const values: Value[] = aboutValuesData.values;
 
   return (
     <section className="relative py-24 bg-gradient-to-b from-card-background via-neutral/20 to-card-background overflow-hidden">
@@ -71,10 +36,10 @@ const AboutValuesSection: React.FC<AboutValuesSectionProps> = ({
           {/* Section Header */}
           <motion.div variants={itemVariants}>
             <SectionHeader
-              badge="Our Values"
-              title="Principles That"
-              subtitle="Define Excellence"
-              description="Five core values that guide every decision we make and every service we provide, ensuring your experience with us is nothing short of exceptional."
+              badge={aboutValuesData.header.badge}
+              title={aboutValuesData.header.title}
+              subtitle={aboutValuesData.header.subtitle}
+              description={aboutValuesData.header.description}
               alignment="left"
               maxWidth="4xl"
               showDecorator={true}

--- a/src/components/About/AboutWhyChooseSection/AboutWhyChooseSection.tsx
+++ b/src/components/About/AboutWhyChooseSection/AboutWhyChooseSection.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { motion, useInView } from "framer-motion";
 import SectionHeader from "@/components/SectionHeader/SectionHeader";
+import { aboutWhyChooseData } from "@/data";
 
 // Counter animation hook
 const useCounter = (end: number, duration: number = 2) => {
@@ -46,10 +47,22 @@ const AboutWhyChooseSection: React.FC<AboutWhyChooseSectionProps> = ({
   itemVariants,
 }) => {
   // Counter hooks for stats
-  const { count: eventsCount, ref: eventsRef } = useCounter(500, 2.5);
-  const { count: clientsCount, ref: clientsRef } = useCounter(98, 3);
-  const { count: yearsCount, ref: yearsRef } = useCounter(8, 2);
-  const { count: specialtiesCount, ref: specialtiesRef } = useCounter(15, 2);
+  const { count: eventsCount, ref: eventsRef } = useCounter(
+    aboutWhyChooseData.stats.events,
+    2.5
+  );
+  const { count: clientsCount, ref: clientsRef } = useCounter(
+    aboutWhyChooseData.stats.clients,
+    3
+  );
+  const { count: yearsCount, ref: yearsRef } = useCounter(
+    aboutWhyChooseData.stats.years,
+    2
+  );
+  const { count: specialtiesCount, ref: specialtiesRef } = useCounter(
+    aboutWhyChooseData.stats.specialties,
+    2
+  );
 
   const trustPoints = [
     {
@@ -68,9 +81,8 @@ const AboutWhyChooseSection: React.FC<AboutWhyChooseSectionProps> = ({
           />
         </svg>
       ),
-      title: "Award-Winning Service",
-      description:
-        "Recognized for excellence in catering and event management by industry professionals and clients alike.",
+      title: aboutWhyChooseData.trustPoints[0].title,
+      description: aboutWhyChooseData.trustPoints[0].description,
     },
     {
       icon: (
@@ -88,9 +100,8 @@ const AboutWhyChooseSection: React.FC<AboutWhyChooseSectionProps> = ({
           />
         </svg>
       ),
-      title: "98% Client Retention",
-      description:
-        "Our clients don't just book us once—they become part of our family and return for every celebration.",
+      title: aboutWhyChooseData.trustPoints[1].title,
+      description: aboutWhyChooseData.trustPoints[1].description,
     },
     {
       icon: (
@@ -108,9 +119,8 @@ const AboutWhyChooseSection: React.FC<AboutWhyChooseSectionProps> = ({
           />
         </svg>
       ),
-      title: "Bespoke Everything",
-      description:
-        "No two events are the same. We customize every detail to reflect your unique vision and preferences.",
+      title: aboutWhyChooseData.trustPoints[2].title,
+      description: aboutWhyChooseData.trustPoints[2].description,
     },
   ];
 
@@ -135,10 +145,10 @@ const AboutWhyChooseSection: React.FC<AboutWhyChooseSectionProps> = ({
           {/* Section Header */}
           <motion.div variants={itemVariants}>
             <SectionHeader
-              badge="Why Choose Us"
-              title="Trusted by Hundreds"
-              subtitle="of Clients"
-              description="Our track record speaks for itself. Here's what sets us apart and why clients return to us for their most important celebrations."
+              badge={aboutWhyChooseData.header.badge}
+              title={aboutWhyChooseData.header.title}
+              subtitle={aboutWhyChooseData.header.subtitle}
+              description={aboutWhyChooseData.header.description}
               alignment="left"
               maxWidth="4xl"
               showDecorator={true}

--- a/src/data/about.ts
+++ b/src/data/about.ts
@@ -1,0 +1,190 @@
+export const aboutIntroData = {
+  header: {
+    badge: "About The OCC",
+    title: "Crafting Moments",
+    subtitle: "Creating Memories",
+    description:
+      "At The OCC Events and Catering, we believe every celebration deserves to be extraordinary. Born from a passion for authentic Indian and Afghan cuisine, we've grown into a trusted partner for life's most meaningful moments.",
+  },
+  paragraph:
+    "Our approach is simple: combine traditional flavours with modern elegance, delivered with the personal touch that makes each event uniquely yours. From intimate gatherings to grand celebrations, we bring authenticity and artistry to every plate.",
+  stats: {
+    value: "125+",
+    description:
+      "Events crafted with care, flavour, and unforgettable memories.",
+  },
+  image: {
+    src: "/images/about/intro-main.jpg",
+    alt: "Elegant dining setup showcasing OCC Events",
+  },
+};
+
+export const aboutStoryData = {
+  header: {
+    badge: "Our Journey",
+    title: "From Humble Beginnings",
+    subtitle: "to Culinary Excellence",
+    description:
+      "Discover the passion and purpose that drives every dish we create and every celebration we craft.",
+  },
+  timeline: [
+    {
+      date: "2016 • The Beginning",
+      text:
+        "The OCC began with a simple dream: to share the rich culinary traditions of India and Afghanistan with our community. What started as intimate gatherings for friends and family has blossomed into something extraordinary.",
+      color: "bg-elements-primary-main",
+    },
+    {
+      date: "The Foundation",
+      text:
+        "Our founder, Amara Singh, grew up surrounded by aromatic spices and time-honored recipes passed down through generations. She recognised that food is more than sustenance — it's the heart of every celebration.",
+      color: "bg-elements-secondary-main",
+    },
+    {
+      date: "Today • Our Promise",
+      text:
+        "We're proud to be the trusted choice for celebrations throughout the region. While we've grown, our commitment remains unchanged: every dish is prepared with love, every event is planned with care.",
+      color: "bg-elements-primary-main",
+    },
+  ],
+  stats: [
+    { label: "Events", value: "500+" },
+    { label: "Years", value: "8+" },
+    { label: "Satisfaction", value: "98%" },
+  ],
+  image: {
+    src: "/images/about/story-image.jpg",
+    alt: "Traditional spices and ingredients",
+  },
+  quote:
+    "Every spice tells a story, every dish carries tradition, and every event we cater becomes a bridge between cultures and hearts.",
+  author: "Amara Singh",
+  authorTitle: "Founder & Executive Chef",
+};
+
+export const aboutTeamData = {
+  header: {
+    badge: "Our Team",
+    title: "The Hearts Behind",
+    subtitle: "Every Event",
+    description:
+      "Meet the passionate individuals who bring creativity, expertise, and genuine care to every celebration we have the honor to be part of.",
+  },
+  members: [
+    {
+      name: "Amara Singh",
+      role: "Founder & Executive Chef",
+      image: "/images/team/amara.jpg",
+      bio: "With over 15 years of culinary excellence, Amara brings authentic Indian and Afghan flavors to every celebration.",
+    },
+    {
+      name: "James Mitchell",
+      role: "Operations Director",
+      image: "/images/team/james.jpg",
+      bio: "James ensures every event runs seamlessly, coordinating logistics with precision and care.",
+    },
+    {
+      name: "Priya Patel",
+      role: "Creative Director",
+      image: "/images/team/priya.jpg",
+      bio: "Priya transforms visions into reality, crafting bespoke experiences that reflect each client's unique story.",
+    },
+    {
+      name: "David Chen",
+      role: "Head of Service",
+      image: "/images/team/david.jpg",
+      bio: "David leads our service team with warmth and professionalism, ensuring every guest feels valued.",
+    },
+  ],
+};
+
+export const aboutValuesData = {
+  header: {
+    badge: "Our Values",
+    title: "Principles That",
+    subtitle: "Define Excellence",
+    description:
+      "Five core values that guide every decision we make and every service we provide, ensuring your experience with us is nothing short of exceptional.",
+  },
+  values: [
+    {
+      number: "01",
+      title: "Personal Touch",
+      description:
+        "Every event is crafted with individual attention, reflecting your unique story and vision. We believe in creating intimate connections through exceptional culinary experiences.",
+      highlight: "Individual Attention",
+    },
+    {
+      number: "02",
+      title: "Authentic Excellence",
+      description:
+        "We honor traditional flavors while embracing modern presentation and dietary preferences. Our heritage recipes meet contemporary sophistication.",
+      highlight: "Traditional Heritage",
+    },
+    {
+      number: "03",
+      title: "Trust & Reliability",
+      description:
+        "Your special moments deserve unwavering commitment. We deliver on every promise, every time, ensuring peace of mind throughout your celebration.",
+      highlight: "Unwavering Commitment",
+    },
+    {
+      number: "04",
+      title: "Creative Innovation",
+      description:
+        "From intimate gatherings to grand celebrations, we bring fresh ideas and artistic flair to every plate and presentation.",
+      highlight: "Fresh Ideas",
+    },
+    {
+      number: "05",
+      title: "Lasting Memories",
+      description:
+        "We don't just cater events; we create experiences that you and your guests will treasure forever. Every detail contributes to unforgettable moments.",
+      highlight: "Unforgettable Moments",
+    },
+  ],
+};
+
+export const aboutWhyChooseData = {
+  header: {
+    badge: "Why Choose Us",
+    title: "Trusted by Hundreds",
+    subtitle: "of Clients",
+    description:
+      "Our track record speaks for itself. Here's what sets us apart and why clients return to us for their most important celebrations.",
+  },
+  stats: {
+    events: 500,
+    clients: 98,
+    years: 8,
+    specialties: 15,
+  },
+  trustPoints: [
+    {
+      title: "Award-Winning Service",
+      description:
+        "Recognized for excellence in catering and event management by industry professionals and clients alike.",
+    },
+    {
+      title: "98% Client Retention",
+      description:
+        "Our clients don't just book us once—they become part of our family and return for every celebration.",
+    },
+    {
+      title: "Bespoke Everything",
+      description:
+        "No two events are the same. We customize every detail to reflect your unique vision and preferences.",
+    },
+  ],
+};
+
+export const aboutCTAData = {
+  backgroundImage: "/images/cta-background.jpg",
+  heading: {
+    preface: "Ready to Create Your",
+    highlight: "Perfect Event?",
+  },
+  description:
+    "Let’s bring your vision to life with our signature blend of authentic flavours and heartfelt service.",
+};
+

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -5,3 +5,4 @@ export * from './testimonials';
 export * from './insta';
 export * from './footer';
 export * from './seo';
+export * from './about';


### PR DESCRIPTION
## Summary
- abstract About page text and image refs into `src/data/about.ts`
- update About page sections to use the new data exports

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a2b94d658832d8da33927820ffd08