### PR TITLE
feat: add basic layouts for service pages

### DIFF
--- a/src/app/services/bespoke-catering/page.tsx
+++ b/src/app/services/bespoke-catering/page.tsx
@@ -1,12 +1,31 @@
-import PageLayout from "@/components/Layouts/PageLayout";
+import SectionHeader from "@/components/SectionHeader/SectionHeader";
 
 export default function BespokeCatering() {
   return (
-    <PageLayout title="Bespoke Catering">
-      <p>
-        Tailor-made menus designed around your tastes and dietary needs for a
-        truly personalised event.
-      </p>
-    </PageLayout>
+    <div className="min-h-screen">
+      <section className="relative py-24 lg:py-36 bg-gradient-to-br from-neutral-dimmed via-main-background to-neutral overflow-hidden">
+        <div className="container mx-auto px-6 lg:px-8">
+          <SectionHeader
+            badge="Bespoke Catering"
+            title="Tailored"
+            subtitle="For Your Event"
+            description="Custom menus designed around your tastes and dietary needs."
+            alignment="center"
+            maxWidth="3xl"
+          />
+        </div>
+      </section>
+
+      <section className="py-24 bg-card-background">
+        <div className="container mx-auto px-6 lg:px-8">
+          <div className="max-w-3xl mx-auto text-center space-y-6">
+            <h2 className="text-2xl font-semibold text-text-primary">Our Promise</h2>
+            <p className="text-text-secondary">
+              Further details will be added soon.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
   );
 }

--- a/src/app/services/event-catering/page.tsx
+++ b/src/app/services/event-catering/page.tsx
@@ -16,6 +16,7 @@ const EventCatering = () => {
       <KeyFeatures />
       <Venues />
       <Testimonials />
+      <CallToAction />
     </div>
   );
 };

--- a/src/app/services/partnered-venues/page.tsx
+++ b/src/app/services/partnered-venues/page.tsx
@@ -1,12 +1,31 @@
-import PageLayout from "@/components/Layouts/PageLayout";
+import SectionHeader from "@/components/SectionHeader/SectionHeader";
 
 export default function PartneredVenues() {
   return (
-    <PageLayout title="Partnered Venues">
-      <p>
-        We collaborate with a selection of trusted venues to host your event,
-        ensuring everything runs smoothly.
-      </p>
-    </PageLayout>
+    <div className="min-h-screen">
+      <section className="relative py-24 lg:py-36 bg-gradient-to-br from-neutral-dimmed via-main-background to-neutral overflow-hidden">
+        <div className="container mx-auto px-6 lg:px-8">
+          <SectionHeader
+            badge="Partnered Venues"
+            title="Trusted Locations"
+            subtitle="For Every Occasion"
+            description="We collaborate with select venues to host seamless events."
+            alignment="center"
+            maxWidth="3xl"
+          />
+        </div>
+      </section>
+
+      <section className="py-24 bg-card-background">
+        <div className="container mx-auto px-6 lg:px-8">
+          <div className="max-w-3xl mx-auto text-center space-y-6">
+            <h2 className="text-2xl font-semibold text-text-primary">Venue Showcase</h2>
+            <p className="text-text-secondary">
+              Information about our venue partners will be shared soon.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
   );
 }

--- a/src/app/services/private-dining/page.tsx
+++ b/src/app/services/private-dining/page.tsx
@@ -1,12 +1,31 @@
-import PageLayout from "@/components/Layouts/PageLayout";
+import SectionHeader from "@/components/SectionHeader/SectionHeader";
 
 export default function PrivateDining() {
   return (
-    <PageLayout title="Private Dining">
-      <p>
-        Enjoy restaurant-quality cuisine in the comfort of your home with our
-        private dining experience.
-      </p>
-    </PageLayout>
+    <div className="min-h-screen">
+      <section className="relative py-24 lg:py-36 bg-gradient-to-br from-neutral-dimmed via-main-background to-neutral overflow-hidden">
+        <div className="container mx-auto px-6 lg:px-8">
+          <SectionHeader
+            badge="Private Dining"
+            title="Restaurant-Quality"
+            subtitle="In Your Home"
+            description="Enjoy bespoke menus and attentive service tailored to intimate gatherings."
+            alignment="center"
+            maxWidth="3xl"
+          />
+        </div>
+      </section>
+
+      <section className="py-24 bg-card-background">
+        <div className="container mx-auto px-6 lg:px-8">
+          <div className="max-w-3xl mx-auto text-center space-y-6">
+            <h2 className="text-2xl font-semibold text-text-primary">Coming Soon</h2>
+            <p className="text-text-secondary">
+              Details about our private dining services will be available soon.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add themed hero and placeholder sections for private dining
- structure partnered venues and bespoke catering pages
- include call to action on event catering page

## Testing
- `npm run lint` *(fails: Unescaped entities in existing components)*

------
https://chatgpt.com/codex/tasks/task_e_68a70ee6d440832dadfb7d80c854577c