### PR TITLE
refactor: unify button styling

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -2,39 +2,43 @@
 
 import React from "react";
 
+const baseButtonClasses =
+  "inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium shadow-sm transition-colors";
+
 const chooseButtonClassName = (type: string) => {
   switch (type) {
     case "warning":
-      return "inline-flex justify-center rounded-md bg-helpers-error-button px-4 py-2 text-sm text-elements-primary-contrastText font-medium shadow-sm ring-1 ring-inset ring-helpers-error-button hover:bg-helpers-error-button-hover items-center";
+      return `${baseButtonClasses} bg-helpers-error-button text-elements-primary-contrastText ring-1 ring-inset ring-helpers-error-button hover:bg-helpers-error-button-hover`;
     case "undo":
-      return "inline-flex justify-center rounded-md bg-neutral-dimmed px-4 py-2 text-sm font-medium ring-1 ring-border-shadow ring-neutral-shadow hover:bg-button-hover items-center text-text-secondary";
+      return `${baseButtonClasses} bg-neutral-dimmed text-text-secondary ring-1 ring-border-shadow ring-neutral-shadow hover:bg-button-hover`;
     case "continue":
-      return "inline-flex justify-center rounded-md bg-elements-primary-main px-4 py-2 text-sm font-medium text-elements-primary-contrastText hover:bg-elements-primary-shadow items-center";
+      return `${baseButtonClasses} bg-elements-primary-main text-elements-primary-contrastText hover:bg-elements-primary-shadow`;
     case "remove":
-      return "inline-flex justify-center rounded-md bg-helpers-remove-button px-4 py-2 text-sm text-elements-primary-contrastText font-medium shadow-sm ring-1 ring-inset ring-helpers-remove-button hover:bg-helpers-remove-button-hover items-center";
+      return `${baseButtonClasses} bg-helpers-remove-button text-elements-primary-contrastText ring-1 ring-inset ring-helpers-remove-button hover:bg-helpers-remove-button-hover`;
     case "text":
-      return "inline-flex justify-center rounded-md px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary items-center";
+      return `${baseButtonClasses} bg-transparent text-text-secondary hover:text-text-primary shadow-none`;
     case "icon":
-      return "inline-flex justify-center items-center rounded-md p-2 text-text-secondary hover:text-text-primary hover:bg-button-hover";
+      return `inline-flex justify-center items-center rounded-md p-2 text-text-secondary hover:text-text-primary hover:bg-button-hover transition-colors`;
     case "hero-primary":
-      return "group relative overflow-hidden inline-flex justify-center items-center px-6 py-3 sm:px-10 sm:py-4 bg-card-background text-text-primary font-medium tracking-wide rounded-sm border border-border-white/20 hover:bg-neutral-dimmed transition-all duration-500 hover:scale-105 hover:shadow-2xl hover:shadow-border-white/10 text-sm sm:text-base";
+      return `group relative overflow-hidden ${baseButtonClasses} px-6 py-3 sm:px-10 sm:py-4 bg-card-background text-text-primary tracking-wide border border-border-white/20 hover:bg-neutral-dimmed duration-500 hover:scale-105 hover:shadow-2xl hover:shadow-border-white/10 text-sm sm:text-base`;
     case "hero-secondary":
-      return "group relative overflow-hidden inline-flex justify-center items-center px-6 py-3 sm:px-10 sm:py-4 bg-transparent text-text-clear font-medium tracking-wide rounded-sm border border-border-white/40 hover:border-border-white/60 transition-all duration-500 hover:scale-105 text-sm sm:text-base";
+      return `group relative overflow-hidden ${baseButtonClasses} px-6 py-3 sm:px-10 sm:py-4 bg-transparent text-text-clear tracking-wide border border-border-white/40 hover:border-border-white/60 duration-500 hover:scale-105 text-sm sm:text-base`;
     case "elegant-primary":
-      return "group relative overflow-hidden inline-flex justify-center items-center px-8 py-3 bg-elements-primary-main text-text-clear font-medium tracking-wide rounded-sm hover:bg-elements-primary-shadow transition-all duration-500 hover:scale-105 hover:shadow-xl hover:shadow-elements-primary-main/25";
+      return `group relative overflow-hidden ${baseButtonClasses} px-8 py-3 bg-elements-primary-main text-text-clear tracking-wide hover:bg-elements-primary-shadow duration-500 hover:scale-105 hover:shadow-xl hover:shadow-elements-primary-main/25`;
     case "elegant-secondary":
-      return "group relative overflow-hidden inline-flex justify-center items-center px-8 py-3 bg-transparent text-text-primary font-medium tracking-wide rounded-sm border border-border-dimmed hover:border-text-primary transition-all duration-500 hover:scale-105";
+      return `group relative overflow-hidden ${baseButtonClasses} px-8 py-3 bg-transparent text-text-primary tracking-wide border border-border-dimmed hover:border-text-primary duration-500 hover:scale-105`;
     case "elegant-outline":
-      return "group relative overflow-hidden inline-flex justify-center items-center px-8 py-3 bg-transparent font-medium tracking-wide rounded-sm border transition-all duration-500 hover:scale-105";
+      return `group relative overflow-hidden ${baseButtonClasses} px-8 py-3 bg-transparent tracking-wide border duration-500 hover:scale-105`;
     default:
-      return "";
+      return baseButtonClasses;
   }
 };
 
 const iconClassName = "flex items-center w-4 h-4";
 
 interface ButtonProps {
-  type?: string;
+  type?: string; // variant
+  buttonType?: "button" | "submit" | "reset";
   extraClassNames?: string;
   children?: React.ReactNode;
   icon?: React.ReactElement;
@@ -48,6 +52,7 @@ interface ButtonProps {
 
 const Button = ({
   type = "continue",
+  buttonType = "button",
   children,
   icon,
   extraClassNames = "",
@@ -105,7 +110,7 @@ const Button = ({
 
   return (
     <button
-      type="button"
+      type={buttonType}
       disabled={disabled}
       className={commonClassNames}
       onClick={handleClick}

--- a/src/components/ContactForm/ContactForm.tsx
+++ b/src/components/ContactForm/ContactForm.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import PrivacyPolicyModal from "@/components/Modal/PrivacyPolicyModal";
 import { motion } from "framer-motion";
 import Modal from "@/components/Modal/Modal";
+import Button from "@/components/Button/Button";
 
 // Toast Component
 const Toast = ({
@@ -285,13 +286,13 @@ const ContactForm: React.FC<FormsProps> = ({
                 className="text-sm text-text-tertiary"
               >
                 By selecting this, you agree to our{" "}
-                <button
-                  type="button"
+                <Button
+                  type="text"
                   onClick={() => setIsPrivacyModalOpen(true)}
-                  className="font-semibold text-elements-primary-main hover:underline"
+                  extraClassNames="font-semibold"
                 >
                   privacy&nbsp;policy
-                </button>
+                </Button>
                 .
               </label>
             </div>
@@ -299,13 +300,14 @@ const ContactForm: React.FC<FormsProps> = ({
 
           {/* Submit Button */}
           <div className="mt-10">
-            <button
-              type="submit"
+            <Button
+              type="continue"
+              buttonType="submit"
               disabled={isSubmitting}
-              className="block w-full rounded-md bg-elements-primary-main px-3.5 py-2.5 text-center text-sm font-semibold text-elements-primary-contrastText shadow-sm hover:bg-elements-primary-shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-elements-primary-main transition-all duration-300 disabled:opacity-70"
+              extraClassNames="w-full"
             >
               {isSubmitting ? "Submitting..." : "Submit"}
-            </button>
+            </Button>
           </div>
         </form>
       </div>

--- a/src/components/Error/ErrorMessage.tsx
+++ b/src/components/Error/ErrorMessage.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { MdErrorOutline } from "react-icons/md";
-import Link from "next/link";
 import { IconBaseProps } from "react-icons";
 import AnimatedDiv from "../AnimatedDiv/AnimatedDiv";
+import Button from "@/components/Button/Button";
 
 const ErrorIcon = MdErrorOutline as unknown as React.FC<IconBaseProps>;
 
@@ -24,19 +24,13 @@ export default function ErrorMessage({
         <p className="text-text-secondary mt-2">{message}</p>
         <div className="mt-6 flex gap-4">
           {reset && (
-            <button
-              onClick={reset}
-              className="px-4 py-2 bg-elements-secondary-main text-white rounded-md hover:bg-elements-secondary-hover transition"
-            >
+            <Button type="continue" onClick={reset}>
               Try Again
-            </button>
+            </Button>
           )}
-          <Link
-            href="/"
-            className="px-4 py-2 bg-neutral text-text-primary rounded-md hover:bg-neutral-shadow transition"
-          >
+          <Button type="continue" href="/">
             Go Home
-          </Link>
+          </Button>
         </div>
       </div>
     </AnimatedDiv>

--- a/src/components/HeroSection/HeroSection.tsx
+++ b/src/components/HeroSection/HeroSection.tsx
@@ -108,7 +108,7 @@ const HeroCarousel: React.FC = () => {
         onClick={handlePrev}
         onMouseEnter={() => setIsAutoPlaying(false)}
         onMouseLeave={() => setIsAutoPlaying(true)}
-        className="absolute left-2 sm:left-8 top-1/2 -translate-y-1/2 z-30 p-2 sm:p-4 bg-border-white/5 backdrop-blur-md border border-border-white/10 text-text-clear hover:bg-border-white/10 transition-all duration-500 group"
+        className="absolute left-2 sm:left-8 top-1/2 -translate-y-1/2 z-30 p-2 sm:p-4 bg-border-white/5 backdrop-blur-md border border-border-white/10 text-text-clear hover:bg-border-white/10 transition-all duration-500 group rounded-md shadow-sm"
         aria-label="Previous image"
       >
         <ChevronLeftIcon className="w-4 h-4 sm:w-5 sm:h-5 group-hover:scale-110 transition-transform duration-300" />
@@ -118,7 +118,7 @@ const HeroCarousel: React.FC = () => {
         onClick={handleNext}
         onMouseEnter={() => setIsAutoPlaying(false)}
         onMouseLeave={() => setIsAutoPlaying(true)}
-        className="absolute right-2 sm:right-8 top-1/2 -translate-y-1/2 z-30 p-2 sm:p-4 bg-border-white/5 backdrop-blur-md border border-border-white/10 text-text-clear hover:bg-border-white/10 transition-all duration-500 group"
+        className="absolute right-2 sm:right-8 top-1/2 -translate-y-1/2 z-30 p-2 sm:p-4 bg-border-white/5 backdrop-blur-md border border-border-white/10 text-text-clear hover:bg-border-white/10 transition-all duration-500 group rounded-md shadow-sm"
         aria-label="Next image"
       >
         <ChevronRightIcon className="w-4 h-4 sm:w-5 sm:h-5 group-hover:scale-110 transition-transform duration-300" />
@@ -185,7 +185,7 @@ const HeroCarousel: React.FC = () => {
             className="mx-auto max-w-2xl text-sm sm:text-lg md:text-xl text-text-clear/90 leading-relaxed mb-8 sm:mb-12 font-light tracking-wide px-4"
           >
             At OCC Events & Catering, we specialise in bespoke Indian and Afghan
-            menus that make every occasion unforgettable. Let's bring your
+            menus that make every occasion unforgettable. Let&apos;s bring your
             celebration to life.
           </motion.p>
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -2,6 +2,7 @@
 
 import React, { ReactNode } from "react";
 import { motion, AnimatePresence, Variants } from "framer-motion";
+import Button from "@/components/Button/Button";
 
 interface ModalProps {
   isOpen: boolean;
@@ -108,12 +109,9 @@ const Modal: React.FC<ModalProps> = ({
 
             {/* Footer */}
             <div className="p-4 border-t border-border-main flex justify-end">
-              <button
-                onClick={onClose}
-                className="px-4 py-2 bg-elements-primary-main text-elements-primary-contrastText rounded-md hover:bg-elements-primary-shadow transition duration-200"
-              >
+              <Button onClick={onClose} type="continue">
                 Close
-              </button>
+              </Button>
             </div>
           </motion.div>
         </motion.div>

--- a/src/components/Navbar/ConfigurableNav/ConfigurableNav.tsx
+++ b/src/components/Navbar/ConfigurableNav/ConfigurableNav.tsx
@@ -161,7 +161,7 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
       wrapper: "",
       header: "",
       navItem: {
-        base: "relative inline-flex items-center px-4 py-2 text-sm font-normal transition-all duration-300 ease-out",
+        base: "relative inline-flex items-center px-4 py-2 text-sm font-normal rounded-md transition-all duration-300 ease-out",
         active: "",
         inactive: "",
         disabled: "opacity-40 cursor-not-allowed",
@@ -172,7 +172,7 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
           "absolute left-1/2 z-50 mt-3 flex w-screen max-w-max -translate-x-1/2",
         panel:
           "w-screen max-w-md flex-auto overflow-hidden rounded-3xl bg-neutral-dimmed-heavy/95 backdrop-blur-2xl border border-border-dimmed/10 shadow-xl shadow-neutral-900/[0.08]",
-        item: "group relative flex gap-x-4 rounded-2xl p-4 hover:bg-neutral/40 transition-all duration-300 ease-out",
+        item: "group relative flex gap-x-4 rounded-md p-4 hover:bg-neutral/40 transition-all duration-300 ease-out",
       },
       mobileMenu: {
         container: "",
@@ -180,7 +180,7 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
         panel:
           "sm:hidden bg-card-background/95 backdrop-blur-xl border-b border-border-dimmed/20 shadow-lg",
         item: {
-          base: "flex items-center px-4 py-3 text-base font-medium rounded-lg transition-all duration-300",
+          base: "flex items-center px-4 py-3 text-base font-medium rounded-md transition-all duration-300",
           active:
             "text-elements-primary-main relative after:absolute after:bottom-1 after:left-4 after:w-8 after:h-0.5 after:bg-gradient-to-r after:from-elements-primary-main after:to-elements-secondary-main after:rounded-full",
           inactive: "text-text-secondary hover:text-elements-primary-main",
@@ -353,7 +353,7 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
                         <div key={subItem.name}>
                           <div className={styles.dropdown.item}>
                             {Icon && (
-                              <div className="flex h-10 w-10 flex-none items-center justify-center rounded-2xl bg-gradient-to-br from-elements-primary-shadow/10 to-elements-secondary-shadow/10 group-hover:from-elements-primary-shadow/20 group-hover:to-elements-secondary-shadow/20 transition-all duration-300">
+                              <div className="flex h-10 w-10 flex-none items-center justify-center rounded-md bg-gradient-to-br from-elements-primary-shadow/10 to-elements-secondary-shadow/10 group-hover:from-elements-primary-shadow/20 group-hover:to-elements-secondary-shadow/20 transition-all duration-300">
                                 <Icon className="h-5 w-5 text-elements-primary-main group-hover:scale-110 transition-transform duration-300" />
                               </div>
                             )}
@@ -376,7 +376,7 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
                                   setDropdownOpen(null);
                                   closeMenu();
                                 }}
-                                className="absolute inset-0 rounded-2xl"
+                                className="absolute inset-0 rounded-md"
                                 aria-label={subItem.name}
                               />
                             )}
@@ -446,7 +446,7 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
         <div key={item.name} className="space-y-1">
           <button
             className={classNames(
-              "flex w-full items-center justify-between px-4 py-3 text-base font-medium rounded-lg transition-all duration-300 relative",
+              "flex w-full items-center justify-between px-4 py-3 text-base font-medium rounded-md transition-all duration-300 relative",
               dropdownOpen === item.name
                 ? "text-elements-primary-main after:absolute after:bottom-1 after:left-4 after:w-8 after:h-0.5 after:bg-gradient-to-r after:from-elements-primary-main after:to-elements-secondary-main after:rounded-full"
                 : "text-text-secondary hover:text-elements-primary-main"
@@ -490,7 +490,7 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
                         href={subHref}
                         scroll={href.startsWith("#")}
                         className={classNames(
-                          "flex items-center px-4 py-2 text-sm font-medium rounded-lg transition-all duration-300 relative",
+                          "flex items-center px-4 py-2 text-sm font-medium rounded-md transition-all duration-300 relative",
                           isSubActive
                             ? "text-elements-primary-main after:absolute after:bottom-0 after:left-4 after:w-6 after:h-0.5 after:bg-gradient-to-r after:from-elements-primary-main after:to-elements-secondary-main after:rounded-full"
                             : "text-text-secondary hover:text-elements-primary-main"
@@ -522,7 +522,7 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
           href={href}
           scroll={href.startsWith("#")}
           className={classNames(
-            "flex items-center px-4 py-3 text-base font-medium rounded-lg transition-all duration-300 relative",
+            "flex items-center px-4 py-3 text-base font-medium rounded-md transition-all duration-300 relative",
             isActive
               ? "text-elements-primary-main after:absolute after:bottom-1 after:left-4 after:w-8 after:h-0.5 after:bg-gradient-to-r after:from-elements-primary-main after:to-elements-secondary-main after:rounded-full"
               : "text-text-secondary hover:text-elements-primary-main"
@@ -539,7 +539,7 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
   const renderMobileMenuButton = () => (
     <button
       onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-      className="p-2 rounded-xl text-text-secondary hover:text-text-primary hover:bg-neutral/50 transition-all duration-200"
+      className="p-2 rounded-md text-text-secondary hover:text-text-primary hover:bg-neutral/50 transition-all duration-200"
       aria-label="Toggle menu"
     >
       <div

--- a/src/components/ThemeSwitcher/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher/ThemeSwitcher.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useTheme } from "next-themes";
 import { motion } from "framer-motion";
+import Button from "@/components/Button/Button";
 
 const ThemeSwitcher = () => {
   const { resolvedTheme, setTheme } = useTheme();
@@ -17,10 +18,11 @@ const ThemeSwitcher = () => {
   if (!mounted) return null;
 
   return (
-    <button
+    <Button
+      type="icon"
       onClick={() => setTheme(isDark ? "light" : "dark")}
-      className="relative p-2.5 rounded-full transition-colors hover:bg-muted"
       aria-label="Toggle theme"
+      extraClassNames="p-2.5"
     >
       <motion.div
         initial={false}
@@ -50,7 +52,7 @@ const ThemeSwitcher = () => {
           </svg>
         )}
       </motion.div>
-    </button>
+    </Button>
   );
 };
 


### PR DESCRIPTION
## Summary
- centralize shared button styles and add HTML button type support
- refactor navigation, theme switcher, modal, and form actions to use common button component
- standardize hover, padding, and rounding across hero and navbar controls

## Testing
- `npm run lint` *(fails: unescaped entity errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a860c26b40832d99b2645107c09bde