### PR TITLE
Fix CTASection button icon type

### DIFF
--- a/src/components/CTASection/CTASection.tsx
+++ b/src/components/CTASection/CTASection.tsx
@@ -8,7 +8,7 @@ interface CTAButton {
   label: string;
   href: string;
   type?: string;
-  icon?: React.ReactNode;
+  icon?: React.ReactElement;
 }
 
 interface CTASectionProps {
@@ -36,7 +36,7 @@ const CTASection: React.FC<CTASectionProps> = ({
       href={action.href}
       extraClassNames="!px-10 !py-4"
       icon={
-        action.icon || (
+        action.icon ?? (
           <svg
             className="w-4 h-4 transition-transform duration-300 group-hover:translate-x-1"
             fill="none"


### PR DESCRIPTION
## Summary
- narrow CTA button icon typing to require React elements to align with Button component expectations
- ensure CTASection falls back to default SVG icon when no custom icon is provided

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d51353472c832dadb9b463c9e27d71